### PR TITLE
Feat status

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -813,6 +813,7 @@ dependencies = [
  "reqwest",
  "serde",
  "serde_derive",
+ "serde_json",
  "tokio",
  "toml",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,8 +13,8 @@ keywords = ["cli", "twitter"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-reqwest = { version = "0.11", features = [ "json" ] }
-tokio = { version = "1", features = [ "full" ] }
+reqwest = { version = "0.11", features = ["json"] }
+tokio = { version = "1", features = ["full"] }
 dotenv = "0.15.0"
 anyhow = "1.0"
 serde = "1.0"
@@ -26,3 +26,4 @@ percent-encoding = "2.1.0"
 base64 = "0.13.0"
 hmac-sha1 = "0.1.3"
 clap = "3.0.0-beta.2"
+serde_json = "1.0"

--- a/Config.toml
+++ b/Config.toml
@@ -1,8 +1,10 @@
-# https://developer.twitter.com/en/portal/apps/new
+# Example of Config.toml
+# It is located on `$HOME/.config/rtwi`
+# You can generate Twitter api key on https://developer.twitter.com/en/portal/apps/new
 
 name = "@earlgrayyyy!!!!"
 
-[client]
+[twitter_api_info]
 api_key = "api_keyyyy!!!!"
 api_secret_key = "api_secret_keyyyy!!!!"
 access_token = "access_tokennnn!!!!"

--- a/Config.toml
+++ b/Config.toml
@@ -1,6 +1,8 @@
 # https://developer.twitter.com/en/portal/apps/new
 
-[config]
+name = "@earlgrayyyy!!!!"
+
+[client]
 api_key = "api_keyyyy!!!!"
 api_secret_key = "api_secret_keyyyy!!!!"
 access_token = "access_tokennnn!!!!"

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
  On twitter, you don't need to find other person's tweets because `twitter` means `a person who tweet`. On RTWI, you can only tweet, so you can experience `Real Twitter`. 
 
 ### High Performance
-Here is a table whith includes times to tweet 'hello everyone' for each client.
+Here is a table which includes times to tweet 'hello everyone' for each client.
 | Client | time(sec) |
 | --- | --- |
 | Twitter Web App | 8.63 |
@@ -16,7 +16,7 @@ Here is a table whith includes times to tweet 'hello everyone' for each client.
 $ git clone https://github.com/earlgray283/rtwi.git
 $ cd rtwi
 $ cargo build --release
-$ cp ./target/release/rtwi {path/to/dir}
+$ cp ./target/release/rtwi path/to/dir
 ```
 or
 ```console
@@ -24,33 +24,46 @@ $ cargo install rtwi
 ```
 
 ## Usage
-### 1. Login  
+### 1. login
+To use `rtwi`, you must generate Twitter API keys.  
+Following console, please create api keys.
 ```console
 $ rtwi login
-...
+.
+.
 ```
-also you can login by creating `$HOME/.config/rtwi/Config.toml` 
+also you can login by creating `$HOME/.config/rtwi/Config.toml`.  
+Please see https://github.com/earlgray283/rtwi/blob/main/Config.toml.
 ```console
 $ mkdir -p $HOME/.config/rtwi/
 $ echo '
+name = "@earlgrayyyy!!!!"
+
+[twitter_api_info]
 api_key = "api_keyyyy!!!!"
 api_secret_key = "api_secret_keyyyy!!!!"
 access_token = "access_tokennnn!!!!"
 access_token_secret = "amazing_mightyyyy!!!!"' > $HOME/.config/rtwi/Config.toml
 ```
 
-#### Attension
-`Config.toml` is located on `$HOME/.config/rtwi`
-
 ### 2. tweet  
 ```console
 $ rtwi tweet 'hello from rtwi. I use †Real Twitter†.'
 status: tweeted
+
 ```
 
-### 3. That's all :D
+### 3. status(TODO)
+```console
+$ rtwi status
+display name: あーるぐれい
+user_id: @earlgray329
+bio: セイロンが好きです
 
-## Configuration
+```
+
+
+## Configuration(TODO)
 If you hope, you can escape from `Real Twitter` and can watch `Timeline` on rtwi.  
 ```toml
 [config]

--- a/src/config.rs
+++ b/src/config.rs
@@ -27,7 +27,16 @@ impl Config {
 
         let mut buf = String::new();
         file.read_to_string(&mut buf).unwrap();
-        let config = toml::from_str::<Config>(&buf)?;
+        let config = match toml::from_str::<Config>(&buf) {
+            Ok(config) => config,
+            Err(e) => {
+                return Err(anyhow!(format!(
+                    "The contents of Config.toml have changed since v0.2.0.
+Sorry, please run 'rtwi login' again.\n{:?}",
+                    &e
+                )))
+            }
+        };
 
         Ok(config)
     }
@@ -47,8 +56,6 @@ pub fn create_config_file() -> Result<()> {
 
     let config = input_config();
     let toml = toml::to_string(&config)?;
-
-
 
     let mut file = File::create(&config_file_path)?;
     if let Err(e) = file.write_all(toml.as_bytes()) {

--- a/src/config.rs
+++ b/src/config.rs
@@ -71,12 +71,6 @@ pub fn open_config_file() -> Result<File> {
     Ok(file)
 }
 
-fn write_config_file(config: &Config) -> Result<()> {
-    let toml = toml::to_string(&config)?;
-
-    Ok(())
-}
-
 pub fn input_config() -> Config {
     print!(
         r#"
@@ -91,10 +85,10 @@ Steps:
 
     let stdin = std::io::stdin();
 
-    let mut api_key = String::new();
-    let mut api_secret_key = String::new();
-    let mut access_token = String::new();
-    let mut access_token_secret = String::new();
+    let mut api_key ;
+    let mut api_secret_key;
+    let mut access_token;
+    let mut access_token_secret;
 
     loop {
         api_key = read_string(&stdin, "api_key = ");
@@ -125,7 +119,7 @@ access_token_secret = {}
     );
     stdout().flush().unwrap();
 
-    let mut name = String::new();
+    let mut name;
     loop {
         name = read_string(&stdin, "");
         if name.strip_prefix("@").is_none() {

--- a/src/config.rs
+++ b/src/config.rs
@@ -9,8 +9,8 @@ use std::{
 
 #[derive(Debug, Deserialize, Serialize)]
 pub struct Config {
-    pub twitter_api_info: TwitterApiInfo,
     pub name: String,
+    pub twitter_api_info: TwitterApiInfo,
 }
 
 #[derive(Debug, Deserialize, Serialize, Clone)]
@@ -48,6 +48,8 @@ pub fn create_config_file() -> Result<()> {
     let config = input_config();
     let toml = toml::to_string(&config)?;
 
+
+
     let mut file = File::create(&config_file_path)?;
     if let Err(e) = file.write_all(toml.as_bytes()) {
         remove_file(&config_file_path)?;
@@ -61,8 +63,9 @@ pub fn open_config_file() -> Result<File> {
     let config_file_path = format!("{}/.config/rtwi/Config.toml", env::var("HOME").unwrap());
     if !Path::new(&config_file_path).exists() {
         return Err(anyhow!(
-            r#"It seems that you didn't create config file :(
-            Please run '$ rtwi login'"#
+            r#"
+    You don't seem to login yet :(
+    Please run '$ rtwi login'"#
         ));
     }
 
@@ -85,43 +88,41 @@ Steps:
 
     let stdin = std::io::stdin();
 
-    let mut api_key ;
+    let mut api_key;
     let mut api_secret_key;
     let mut access_token;
     let mut access_token_secret;
 
     loop {
-        api_key = read_string(&stdin, "api_key = ");
-        api_secret_key = read_string(&stdin, "api_secret_key = ");
-        access_token = read_string(&stdin, "access_token = ");
-        access_token_secret = read_string(&stdin, "access_token_secret = ");
+        api_key = read_string(&stdin, "    api_key = ");
+        api_secret_key = read_string(&stdin, "    api_secret_key = ");
+        access_token = read_string(&stdin, "    access_token = ");
+        access_token_secret = read_string(&stdin, "    access_token_secret = ");
 
         let prmt = &format!(
             r#"
-====== Confirm ======
-api_key = {}
-api_secret_key = {}
-access_token = {}
-access_token_secret = {}
-"#,
+================== Confirm ==================
+    api_key = {}
+    api_secret_key = {}
+    access_token = {}
+    access_token_secret = {}
+
+If you are OK, then please type y, else type n > "#,
             api_key, api_secret_key, access_token, access_token_secret
         );
         let yn = read_string(&stdin, prmt);
+        stdout().flush().unwrap();
         if yn.trim_end() == "y".to_string() {
+            println!();
             break;
         }
     }
 
-    print!(
-        r#"
- 3. Please input your twitter screen_name. (example: screen_name = @earlgray329)
- screen_name = "#
-    );
-    stdout().flush().unwrap();
+    println!("3. Please input your twitter screen_name. (example: screen_name = @earlgray329)");
 
     let mut name;
     loop {
-        name = read_string(&stdin, "");
+        name = read_string(&stdin, "    screen_name = ");
         if name.strip_prefix("@").is_none() {
             println!("screen_name must have a prefix of @. (example: screen_name = @earlgray329)");
             continue;

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,6 +1,37 @@
-use std::{env, fs::create_dir, io::{Write, stdout}, path::Path};
-use anyhow::Result;
-use tokio::{fs::File, io::AsyncWriteExt};
+use anyhow::{anyhow, Result};
+use serde_derive::{Deserialize, Serialize};
+use std::{
+    env,
+    fs::{create_dir, remove_file, File},
+    io::{stdout, Read, Write},
+    path::Path,
+};
+
+#[derive(Debug, Deserialize, Serialize)]
+pub struct Config {
+    pub twitter_api_info: TwitterApiInfo,
+    pub name: String,
+}
+
+#[derive(Debug, Deserialize, Serialize, Clone)]
+pub struct TwitterApiInfo {
+    pub api_key: String,
+    pub api_secret_key: String,
+    pub access_token: String,
+    pub access_token_secret: String,
+}
+
+impl Config {
+    pub fn new() -> Result<Self> {
+        let mut file = open_config_file()?;
+
+        let mut buf = String::new();
+        file.read_to_string(&mut buf).unwrap();
+        let config = toml::from_str::<Config>(&buf)?;
+
+        Ok(config)
+    }
+}
 
 pub fn create_config_dir() -> Result<()> {
     let config_dir_path = format!("{}/.config/rtwi", env::var("HOME").unwrap());
@@ -11,30 +42,42 @@ pub fn create_config_dir() -> Result<()> {
     Ok(())
 }
 
-pub async fn create_config_file() -> Result<()> {
+pub fn create_config_file() -> Result<()> {
     let config_file_path = format!("{}/.config/rtwi/Config.toml", env::var("HOME").unwrap());
-    
-    let mut file = File::create(&config_file_path).await?;
-    if let Err(e) = input_config(&mut file).await {
-        std::fs::remove_file(&config_file_path).unwrap();
-        return Err(e);
+
+    let config = input_config();
+    let toml = toml::to_string(&config)?;
+
+    let mut file = File::create(&config_file_path)?;
+    if let Err(e) = file.write_all(toml.as_bytes()) {
+        remove_file(&config_file_path)?;
+        return Err(anyhow!(e));
     }
 
     Ok(())
 }
 
-pub async fn open_config_file() -> Result<File> {
+pub fn open_config_file() -> Result<File> {
     let config_file_path = format!("{}/.config/rtwi/Config.toml", env::var("HOME").unwrap());
     if !Path::new(&config_file_path).exists() {
-        return Err(anyhow::Error::msg("It seems that you didn't create config file :("));
+        return Err(anyhow!(
+            r#"It seems that you didn't create config file :(
+            Please run '$ rtwi login'"#
+        ));
     }
 
-    let file = File::open(&config_file_path).await?;
+    let file = File::open(&config_file_path)?;
 
     Ok(file)
 }
 
-pub async fn input_config(file: &mut File) -> Result<()> {
+fn write_config_file(config: &Config) -> Result<()> {
+    let toml = toml::to_string(&config)?;
+
+    Ok(())
+}
+
+pub fn input_config() -> Config {
     print!(
         r#"
 Welcome to RTWI!
@@ -44,63 +87,71 @@ Steps:
   2. Please input "api_key", "api_secret_key", "access_token", "access_token_secret" in order.
 "#
     );
+    stdout().flush().unwrap();
 
     let stdin = std::io::stdin();
 
+    let mut api_key = String::new();
+    let mut api_secret_key = String::new();
+    let mut access_token = String::new();
+    let mut access_token_secret = String::new();
+
     loop {
-        print!("api_key = ");
-        stdout().flush().unwrap();
-        let mut api_key = String::new();
-        stdin.read_line(&mut api_key).unwrap();
-        api_key = api_key.trim_end().to_string();
+        api_key = read_string(&stdin, "api_key = ");
+        api_secret_key = read_string(&stdin, "api_secret_key = ");
+        access_token = read_string(&stdin, "access_token = ");
+        access_token_secret = read_string(&stdin, "access_token_secret = ");
 
-        print!("api_secret_key = ");
-        stdout().flush().unwrap();
-        let mut api_secret_key = String::new();
-        stdin.read_line(&mut api_secret_key).unwrap();
-        api_secret_key = api_secret_key.trim_end().to_string();
-
-        print!("access_token = ");
-        stdout().flush().unwrap();
-        let mut access_token = String::new();
-        stdin.read_line(&mut access_token).unwrap();
-        access_token = access_token.trim_end().to_string();
-
-        print!("access_token_secret = ");
-        stdout().flush().unwrap();
-        let mut access_token_secret = String::new();
-        stdin.read_line(&mut access_token_secret).unwrap();
-        access_token_secret = access_token_secret.trim_end().to_string();
-
-        print!(
+        let prmt = &format!(
             r#"
-        === Confirm ===
-        api_key = {}
-        api_secret_key = {}
-        access_token = {}
-        access_token_secret = {}
-        "#,
+====== Confirm ======
+api_key = {}
+api_secret_key = {}
+access_token = {}
+access_token_secret = {}
+"#,
             api_key, api_secret_key, access_token, access_token_secret
         );
-
-        print!("Please input y or n > ");
-        stdout().flush().unwrap();
-        let mut yn = String::new();
-        stdin.read_line(&mut yn).unwrap();
-
+        let yn = read_string(&stdin, prmt);
         if yn.trim_end() == "y".to_string() {
-            let tmp = super::twitter_api::Client {
-                api_key,
-                api_secret_key,
-                access_token,
-                access_token_secret,
-            };
-
-            let toml = toml::to_string(&tmp)?;
-            file.write_all(toml.as_bytes()).await?;
             break;
         }
     }
 
-    Ok(())
+    print!(
+        r#"
+ 3. Please input your twitter screen_name. (example: screen_name = @earlgray329)
+ screen_name = "#
+    );
+    stdout().flush().unwrap();
+
+    let mut name = String::new();
+    loop {
+        name = read_string(&stdin, "");
+        if name.strip_prefix("@").is_none() {
+            println!("screen_name must have a prefix of @. (example: screen_name = @earlgray329)");
+            continue;
+        }
+
+        break;
+    }
+
+    Config {
+        name,
+        twitter_api_info: TwitterApiInfo {
+            api_key,
+            api_secret_key,
+            access_token,
+            access_token_secret,
+        },
+    }
+}
+
+fn read_string(stdin: &std::io::Stdin, prompt: &str) -> String {
+    print!("{}", prompt);
+    stdout().flush().unwrap();
+
+    let mut buf = String::new();
+    stdin.read_line(&mut buf).unwrap();
+    buf.trim_end().to_string()
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -40,6 +40,7 @@ async fn main() -> Result<()> {
             let config = Config::new()?;
             let client = Client::new(&config);
             let _res = client.tweet(&tweet.text).await?;
+            print!("status: tweeted\n\n");
         }
         SubCommand::Logout => {
             todo!();

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,6 +5,7 @@ use twitter_api::Client;
 
 mod config;
 mod twitter_api;
+mod sub_command;
 
 #[derive(Clap)]
 #[clap(version = "0.1.12", author = "earlgray <@earlgray329>")]
@@ -39,8 +40,17 @@ async fn main() -> Result<()> {
         SubCommand::Tweet(tweet) => {
             let config = Config::new()?;
             let client = Client::new(&config);
-            let _res = client.tweet(&tweet.text).await?;
-            print!("status: tweeted\n\n");
+
+            let res = client.tweet(&tweet.text).await;
+
+            println!(
+                "status: {}",
+                if res.is_ok() {
+                    "tweeted".to_string()
+                } else {
+                    format!("error\n{:?}", res.map_err(|e| e))
+                }
+            )
         }
         SubCommand::Logout => {
             todo!();
@@ -48,8 +58,9 @@ async fn main() -> Result<()> {
         SubCommand::Status => {
             let config = Config::new()?;
             let client = Client::new(&config);
-            let res = client.show_profile(Some(&config.name), None).await?;
-            println!("{:?}", &res);
+
+            let user_info = client.get_profile(Some(&config.name), None).await?;
+            sub_command::show_profile(&user_info);
         }
     }
 

--- a/src/sub_command.rs
+++ b/src/sub_command.rs
@@ -1,0 +1,6 @@
+use super::twitter_api::user::UserInfo;
+pub fn show_profile(user_info: &UserInfo) {
+    println!("name: \n  {} (@{})", user_info.name, user_info.screen_name);
+    println!();
+    println!("bio: \n   {}", user_info.bio);
+}

--- a/src/twitter_api.rs
+++ b/src/twitter_api.rs
@@ -1,4 +1,4 @@
-use super::config;
+use super::config::Config;
 use anyhow::Result;
 use percent_encoding::{utf8_percent_encode, AsciiSet, NON_ALPHANUMERIC};
 use rand::{distributions::Alphanumeric, thread_rng, Rng};
@@ -8,9 +8,9 @@ use reqwest::{
 };
 use serde_derive::{Deserialize, Serialize};
 use std::collections::BTreeMap;
-use tokio::io::AsyncReadExt;
 
 mod tweet;
+mod user;
 
 #[derive(Debug, Deserialize, Serialize)]
 pub struct Client {
@@ -21,15 +21,13 @@ pub struct Client {
 }
 
 impl Client {
-    pub async fn from_config() -> Result<Self> {
-        config::create_config_dir()?;
-        let mut file = config::open_config_file().await?;
-
-        let mut buf = String::new();
-        file.read_to_string(&mut buf).await.unwrap();
-        let client = toml::from_str::<Client>(&buf)?;
-
-        Ok(client)
+    pub fn new(config: &Config) -> Self {
+        Self {
+            api_key: config.twitter_api_info.api_key.clone(),
+            api_secret_key: config.twitter_api_info.api_secret_key.clone(),
+            access_token: config.twitter_api_info.access_token.clone(),
+            access_token_secret: config.twitter_api_info.access_token_secret.clone(),
+        }
     }
 
     async fn request(

--- a/src/twitter_api.rs
+++ b/src/twitter_api.rs
@@ -9,8 +9,8 @@ use reqwest::{
 use serde_derive::{Deserialize, Serialize};
 use std::collections::BTreeMap;
 
-mod tweet;
-mod user;
+pub mod tweet;
+pub mod user;
 
 #[derive(Debug, Deserialize, Serialize)]
 pub struct Client {
@@ -152,6 +152,7 @@ fn percent_encode(s: &str) -> percent_encoding::PercentEncode {
 trait Collect {
     fn equal_collect(&self) -> Vec<String>;
 }
+
 impl Collect for Vec<(&str, &str)> {
     fn equal_collect(&self) -> Vec<String> {
         self.iter()

--- a/src/twitter_api/tweet.rs
+++ b/src/twitter_api/tweet.rs
@@ -1,14 +1,20 @@
-use std::collections::BTreeMap;
-use reqwest::{Method, Response};
 use super::Client;
+use anyhow::anyhow;
+use reqwest::{Method, StatusCode};
+use std::collections::BTreeMap;
 
 impl Client {
-    pub async fn tweet(&self, status: &str) -> Result<Response, reqwest::Error> {
+    pub async fn tweet(&self, status: &str) -> Result<(), anyhow::Error> {
         const ENDPOINT: &str = "https://api.twitter.com/1.1/statuses/update.json";
 
         let mut params = BTreeMap::new();
         params.insert("status", status);
 
-        self.request(Method::POST, ENDPOINT, &params).await
+        let res = self.request(Method::POST, ENDPOINT, &params).await?;
+        if res.status() != StatusCode::OK {
+            Err(anyhow!(format!("status-code: {}", res.status())))
+        } else {
+            Ok(())
+        }
     }
 }

--- a/src/twitter_api/user.rs
+++ b/src/twitter_api/user.rs
@@ -1,10 +1,20 @@
-use std::collections::BTreeMap;
-use anyhow::anyhow;
-use reqwest::{Method, Response};
 use super::Client;
+use anyhow::anyhow;
+use reqwest::{Method, StatusCode};
+use serde_json::Value;
+use std::collections::BTreeMap;
 
+pub struct UserInfo {
+    pub name: String,
+    pub screen_name: String,
+    pub bio: String,
+}
 impl Client {
-    pub async fn show_profile(&self, name: Option<&str>, user_id: Option<&str>) -> Result<Response, anyhow::Error> {
+    pub async fn get_profile(
+        &self,
+        name: Option<&str>,
+        user_id: Option<&str>,
+    ) -> Result<UserInfo, anyhow::Error> {
         const ENDPOINT: &str = "https://api.twitter.com/1.1/users/show.json";
 
         if name.is_none() && user_id.is_none() {
@@ -18,6 +28,17 @@ impl Client {
             parms.insert("user_id", user_id);
         }
 
-        Ok(self.request(Method::GET, ENDPOINT, &parms).await?)
+        let res = self.request(Method::GET, ENDPOINT, &parms).await?;
+        if res.status() != StatusCode::OK {
+            return Err(anyhow!("failed to get status."));
+        }
+
+        let value = serde_json::from_str::<Value>(&res.text().await?)?;
+
+        Ok(UserInfo {
+            name: value["name"].to_string(),
+            screen_name: value["screen_name"].to_string(),
+            bio: value["description"].to_string(),
+        })
     }
 }

--- a/src/twitter_api/user.rs
+++ b/src/twitter_api/user.rs
@@ -1,0 +1,23 @@
+use std::collections::BTreeMap;
+use anyhow::anyhow;
+use reqwest::{Method, Response};
+use super::Client;
+
+impl Client {
+    pub async fn show_profile(&self, name: Option<&str>, user_id: Option<&str>) -> Result<Response, anyhow::Error> {
+        const ENDPOINT: &str = "https://api.twitter.com/1.1/users/show.json";
+
+        if name.is_none() && user_id.is_none() {
+            return Err(anyhow!("user_id or name must be set"));
+        }
+
+        let mut parms = BTreeMap::new();
+        if let Some(name) = name {
+            parms.insert("screen_name", name);
+        } else if let Some(user_id) = user_id {
+            parms.insert("user_id", user_id);
+        }
+
+        Ok(self.request(Method::GET, ENDPOINT, &parms).await?)
+    }
+}


### PR DESCRIPTION
fix: #1 

# 新機能
+ `$ rtwi status` でプロフィールが閲覧できるようになりました
```console
❯ cargo run status
name: 
  "あーるぐれい" (@"earlgray329")

bio: 
   "B1 / Rust, Golang, C / Regolith Linux / 好き: 真壁瑞希、セイロン、音ゲー(ウニ, Arcaea)"

```

# 変更点
## config.rs
+ async の使用をやめた
+ config の api keys と client の api keys を区別するために、`TwitterApiInfo` 構造体を作りました。
+ `read_string` 関数で入力するようにしました。

## tweet.rs
+ `tweet` 関数の中でレスポンスのステータスコードを読み、`200` だったら `Ok(())` を返し、それ以外だったら `Err(&str)` を返すようにしました。

## user.rs
+ 名前と id と bio を返すような `get_profile` 関数を作りました。

## Config.toml
+ File changed を見てください。